### PR TITLE
Support mosquitto_tls_insecure_set

### DIFF
--- a/mosquitto-rs/src/client.rs
+++ b/mosquitto-rs/src/client.rs
@@ -506,22 +506,30 @@ impl Client {
             .configure_tls(ca_file, ca_path, cert_file, key_file, pw_callback)
     }
 
-    /// Configure verification of the server hostname in the server certificate.
-    /// If value is set to true, it is impossible to guarantee that the host you
+    /// Disables verification of the server hostname in the server certificate.
+    /// If this is disabled, it is impossible to guarantee that the host you
     /// are connecting to is not impersonating your server.  This can be useful
     /// in initial server testing, but makes it possible for a malicious third
     /// party to impersonate your server through DNS spoofing, for example.  Do
-    /// not use this function in a real system.  Setting value to true makes the
-    /// connection encryption pointless.  Must be called before mosquitto_connect.
-    /// 
-    /// If `value`	if set to false, the default, certificate hostname checking is
-    /// performed.  If set to true, no hostname checking is performed and the
-    /// connection is insecure.
-    pub fn mosquitto_tls_insecure_set(
+    /// not use this function in a real system.  Disabling this makes the
+    /// connection encryption pointless.  Must be called before connect.
+    pub fn disable_tls_hostname_validation(
         &self,
-        value: bool
     ) -> Result<(), Error> {
-        self.mosq.mosquitto_tls_insecure_set(value)
+        self.mosq.set_tls_insecure(true)
+    }
+
+    /// Enables verification of the server hostname in the server certificate.
+    /// By default this validation is enabled. If this is disabled, it is
+    /// impossible to guarantee that the host you are connecting to is not
+    /// impersonating your server.  This can be useful in initial server
+    /// testing, but makes it possible for a malicious third party to
+    /// impersonate your server through DNS spoofing, for example. Must be
+    /// called before connect.
+    pub fn enable_tls_hostname_validation(
+        &self,
+    ) -> Result<(), Error> {
+        self.mosq.set_tls_insecure(false)
     }
 
     /// Controls reconnection behavior when running in the message loop.

--- a/mosquitto-rs/src/client.rs
+++ b/mosquitto-rs/src/client.rs
@@ -513,9 +513,7 @@ impl Client {
     /// party to impersonate your server through DNS spoofing, for example.  Do
     /// not use this function in a real system.  Disabling this makes the
     /// connection encryption pointless.  Must be called before connect.
-    pub fn disable_tls_hostname_validation(
-        &self,
-    ) -> Result<(), Error> {
+    pub fn disable_tls_hostname_validation(&self) -> Result<(), Error> {
         self.mosq.set_tls_insecure(true)
     }
 
@@ -526,9 +524,7 @@ impl Client {
     /// testing, but makes it possible for a malicious third party to
     /// impersonate your server through DNS spoofing, for example. Must be
     /// called before connect.
-    pub fn enable_tls_hostname_validation(
-        &self,
-    ) -> Result<(), Error> {
+    pub fn enable_tls_hostname_validation(&self) -> Result<(), Error> {
         self.mosq.set_tls_insecure(false)
     }
 

--- a/mosquitto-rs/src/client.rs
+++ b/mosquitto-rs/src/client.rs
@@ -506,6 +506,24 @@ impl Client {
             .configure_tls(ca_file, ca_path, cert_file, key_file, pw_callback)
     }
 
+    /// Configure verification of the server hostname in the server certificate.
+    /// If value is set to true, it is impossible to guarantee that the host you
+    /// are connecting to is not impersonating your server.  This can be useful
+    /// in initial server testing, but makes it possible for a malicious third
+    /// party to impersonate your server through DNS spoofing, for example.  Do
+    /// not use this function in a real system.  Setting value to true makes the
+    /// connection encryption pointless.  Must be called before mosquitto_connect.
+    /// 
+    /// If `value`	if set to false, the default, certificate hostname checking is
+    /// performed.  If set to true, no hostname checking is performed and the
+    /// connection is insecure.
+    pub fn mosquitto_tls_insecure_set(
+        &self,
+        value: bool
+    ) -> Result<(), Error> {
+        self.mosq.mosquitto_tls_insecure_set(value)
+    }
+
     /// Controls reconnection behavior when running in the message loop.
     /// By default, if a client is unexpectedly disconnected, mosquitto will
     /// try to reconnect.  The default reconnect parameters are to retry once

--- a/mosquitto-rs/src/lowlevel.rs
+++ b/mosquitto-rs/src/lowlevel.rs
@@ -482,6 +482,30 @@ impl<CB: Callbacks + Send + Sync> Mosq<CB> {
         Error::result(err, ())
     }
 
+    /// Configure verification of the server hostname in the server certificate.
+    /// If value is set to true, it is impossible to guarantee that the host you
+    /// are connecting to is not impersonating your server.  This can be useful
+    /// in initial server testing, but makes it possible for a malicious third
+    /// party to impersonate your server through DNS spoofing, for example.  Do
+    /// not use this function in a real system.  Setting value to true makes the
+    /// connection encryption pointless.  Must be called before mosquitto_connect.
+    /// 
+    /// If `value`	if set to false, the default, certificate hostname checking is
+    /// performed.  If set to true, no hostname checking is performed and the
+    /// connection is insecure.
+    pub fn mosquitto_tls_insecure_set(
+        &self,
+        value: bool
+    ) -> Result<(), Error> {
+        let err = unsafe {
+            sys::mosquitto_tls_insecure_set(
+                self.m,
+                value,
+            );
+        };
+        Error::result(err, ())
+    }
+
     /// Controls reconnection behavior when running in the message loop.
     /// By default, if a client is unexpectedly disconnected, mosquitto will
     /// try to reconnect.  The default reconnect parameters are to retry once

--- a/mosquitto-rs/src/lowlevel.rs
+++ b/mosquitto-rs/src/lowlevel.rs
@@ -489,20 +489,12 @@ impl<CB: Callbacks + Send + Sync> Mosq<CB> {
     /// party to impersonate your server through DNS spoofing, for example.  Do
     /// not use this function in a real system.  Setting value to true makes the
     /// connection encryption pointless.  Must be called before mosquitto_connect.
-    /// 
+    ///
     /// If `value`	if set to false, the default, certificate hostname checking is
     /// performed.  If set to true, no hostname checking is performed and the
     /// connection is insecure.
-    pub fn set_tls_insecure(
-        &self,
-        value: bool
-    ) -> Result<(), Error> {
-        let err = unsafe {
-            sys::mosquitto_tls_insecure_set(
-                self.m,
-                value,
-            )
-        };
+    pub fn set_tls_insecure(&self, value: bool) -> Result<(), Error> {
+        let err = unsafe { sys::mosquitto_tls_insecure_set(self.m, value) };
         Error::result(err, ())
     }
 

--- a/mosquitto-rs/src/lowlevel.rs
+++ b/mosquitto-rs/src/lowlevel.rs
@@ -493,7 +493,7 @@ impl<CB: Callbacks + Send + Sync> Mosq<CB> {
     /// If `value`	if set to false, the default, certificate hostname checking is
     /// performed.  If set to true, no hostname checking is performed and the
     /// connection is insecure.
-    pub fn mosquitto_tls_insecure_set(
+    pub fn set_tls_insecure(
         &self,
         value: bool
     ) -> Result<(), Error> {

--- a/mosquitto-rs/src/lowlevel.rs
+++ b/mosquitto-rs/src/lowlevel.rs
@@ -501,7 +501,7 @@ impl<CB: Callbacks + Send + Sync> Mosq<CB> {
             sys::mosquitto_tls_insecure_set(
                 self.m,
                 value,
-            );
+            )
         };
         Error::result(err, ())
     }


### PR DESCRIPTION
Adds mosquitto_tls_insecure_set to Client.

I have no strong opinions on the name so feel free to suggest something else. The current name is just the one used by mosquitto. In openssl wrappers I've seen the name changed to reflect how dangerous this function is in most situations.

Much as I don't like this option I need to use it in an environment where we don't actually have DNS so the server name and cert will never match.
